### PR TITLE
Fix title screen button selection ordering when multiple custom buttons are added & Update ccmod.json

### DIFF
--- a/ccmod.json
+++ b/ccmod.json
@@ -1,8 +1,11 @@
 {
-	"id": "preset-revival-plus",
-	"version": "2.1.0",
-	"module": true,
-	"title": "Preset Revival Plus",
-	"description": "Brings back the preset menu, which allows you to start the game at a specific point.",
-	"prestart": "prestart.js"
+  "id": "preset-revival-plus",
+  "version": "2.1.0",
+  "title": "Preset Revival Plus",
+  "description": "Brings back the preset menu, which allows you to start the game at a specific point.",
+  "repository": "https://github.com/EpicYoshiMaster/CCPresetRevivalPlus",
+  "tags": ["speedrun", "dev"],
+  "authors": ["ac2pic", "2767mr", "EpicYoshiMaster"],
+  "prestart": "prestart.js"
 }
+

--- a/prestart.js
+++ b/prestart.js
@@ -4,7 +4,7 @@ const NO_PRESETS_FOUND = "No Presets Found";
 sc.TitleScreenButtonGui.inject({
 	init() {
 		this.parent();
-		this._createButton("preset", this.buttons.last().hook.pos.y + 39, this.buttons.length + 1, () => {
+		this._createButton("preset", this.buttons.last().hook.pos.y + 39, 100 - this.buttons.length, () => {
 			this.background.doStateTransition("DEFAULT");
 			this.presetMenu.activate();
 		}, "preset");


### PR DESCRIPTION
When you add more title screen buttons, the gamepad selection order is reversed, so I did this trick.
I do the same in both of my mods that use title screen buttons, it works fine.

Updated `ccmod.json` to the new standard